### PR TITLE
允许设置文件存储目录，而不是固定的目录

### DIFF
--- a/internal/cli.go
+++ b/internal/cli.go
@@ -28,12 +28,10 @@ type Cli struct {
 	files         []*aliyundrive.File
 }
 
-func NewCli() *Cli {
+func NewCli(homedir string) *Cli {
 	fileStack := stack.New()
 	fileStack.Push("root")
-	home, _ := os.UserHomeDir()
-	downloadDir := home + "/Downloads/aliyundrive-cli"
-	_ = os.MkdirAll(downloadDir, 0o777)
+	_ = os.MkdirAll(homedir, 0o777)
 
 	return &Cli{
 		ali:           aliyundrive.New(),
@@ -41,7 +39,7 @@ func NewCli() *Cli {
 		fileIDs:       []string{"root"},
 		currentFileID: "root",
 		fileStack:     fileStack,
-		downloadDir:   downloadDir,
+		downloadDir:   homedir,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 
 	"runtime/debug"
 
@@ -12,9 +13,13 @@ import (
 )
 
 var version bool
+var dir string
 
 func init() {
+	home, _ := os.UserHomeDir()
+	downloadDir := path.Join(home, "/Downloads/aliyundrive-cli")
 	flag.BoolVar(&version, "version", false, "Print program version")
+	flag.StringVar(&dir, "dir", downloadDir, "File download directory")
 	if !flag.Parsed() {
 		flag.Parse()
 	}
@@ -31,7 +36,9 @@ func main() {
 	oldTermiosPtr := internal.IoctlGetTermios()
 	defer internal.IoctlSetTermios(oldTermiosPtr)
 
-	cli := internal.NewCli()
+	println(dir)
+	os.Stdout.Sync()
+	cli := internal.NewCli(dir)
 	fmt.Println("阿里云盘命令行客户端")
 
 	p := prompt.New(cli.Executor, cli.Completer, prompt.OptionLivePrefix(cli.Prefix))


### PR DESCRIPTION
允许设置文件存储目录，而不是固定的目录
```
hellojukay@local aliyundrive-cli (homedir) $ ./aliyundrive-cli -h
Usage of ./aliyundrive-cli:
  -dir string
        Print program version (default "/home/hellojukay/Downloads/aliyundrive-cli")
  -version
        Print program version

```