### PR TITLE
解决文件名字中包含空格的时候 mv 报错的问题

### DIFF
--- a/internal/command.go
+++ b/internal/command.go
@@ -58,7 +58,7 @@ func (r *Cli) ParseCommand(input string) (Command, error) {
 		if len(l) != 2 {
 			return nil, fmt.Errorf("mv 命令不合法，需要两个以空格区分的参数，如: mv old new")
 		}
-		return &CommandMv{cli: r, from: strings.TrimSpace(l[0]), to: strings.TrimSpace(l[1])}, nil
+		return &CommandMv{cli: r, from: l[0], to: l[1]}, nil
 	}
 	if strings.HasPrefix(input, "help") || strings.HasPrefix(input, "?") {
 		return nil, errors.New(CommandUsage)

--- a/internal/command_ls.go
+++ b/internal/command_ls.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chyroc/go-aliyundrive"
 )
@@ -53,7 +54,7 @@ func (r *Cli) findFileByName(name string) (*aliyundrive.File, error) {
 			return v, nil
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("文件: \"%s\" 未找到", name)
 }
 
 func (r *Cli) removeByName(name string) (*aliyundrive.File, error) {

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -34,30 +34,31 @@ func inText(key, text string) bool {
 }
 
 func splitSpace(s string) []string {
-	res := []string{}
-	buf := []rune{}
-	z := false
-	for _, v := range []rune(s) {
-		if v == '\\' {
-			z = true
-			continue
-		} else if v == ' ' {
-			if z {
-				buf = append(buf, v)
-				z = false
-			} else {
-				z = false
-				if len(buf) > 0 {
-					res = append(res, string(buf))
-					buf = []rune{}
-				}
-			}
-		} else {
-			buf = append(buf, v)
+	s = strings.Trim(s, " ")
+	var parmChars = []rune(s)
+	var inSingleQuote = false
+	var inDoubleQuote = false
+	for index, ch := range parmChars {
+		if ch == '"' && !inSingleQuote {
+			inDoubleQuote = !inDoubleQuote
+			parmChars[index] = '\n'
+		}
+		if parmChars[index] == '\'' && !inDoubleQuote {
+			inSingleQuote = !inSingleQuote
+			parmChars[index] = '\n'
+		}
+		if !inSingleQuote && !inDoubleQuote && parmChars[index] == ' ' {
+			parmChars[index] = '\n'
 		}
 	}
-	if len(buf) > 0 {
-		res = append(res, string(buf))
+	var list = strings.Split(string(parmChars), "\n")
+	var result []string
+	for _, s := range list {
+		if s == "" {
+			continue
+		}
+		result = append(result, s)
 	}
-	return res
+	return result
+
 }

--- a/internal/helper_test.go
+++ b/internal/helper_test.go
@@ -54,6 +54,5 @@ func Test_inText(t *testing.T) {
 func Test_splitSpace(t *testing.T) {
 	as := assert.New(t)
 
-	as.Equal([]string{"a b", "c"}, splitSpace(`a\ b c`))
-	as.Equal([]string{"a b", "c"}, splitSpace(`a\ b c  `))
+	as.Equal([]string{"Go 进阶训练营-2.微服务可用性设计（下）2(224732).mp4", "Go 进阶训练营-2.mp4"}, splitSpace(`"Go 进阶训练营-2.微服务可用性设计（下）2(224732).mp4" "Go 进阶训练营-2.mp4"`))
 }


### PR DESCRIPTION
fixed #19 
参考： https://stackoverflow.com/questions/298830/split-string-containing-command-line-parameters-into-string-in-c-sharp