### PR TITLE
解决上传文件夹路径错误及上传时路径栈没出栈

### DIFF
--- a/internal/command_upload.go
+++ b/internal/command_upload.go
@@ -75,8 +75,8 @@ func (r *CommandUpload) upload(file string, driveID string, fileID string) error
 			log.Fatal(err)
 		}
 		response, err := r.cli.ali.File.CreateFolder(context.Background(), &aliyundrive.CreateFolderReq{
-			DriveID:      r.cli.driveID,
-			ParentFileID: r.cli.currentFileID,
+			DriveID:      driveID,
+			ParentFileID: fileID,
 			Name:         fileInfo.Name(),
 		})
 		if err != nil {
@@ -92,6 +92,8 @@ func (r *CommandUpload) upload(file string, driveID string, fileID string) error
 			}
 			fmt.Printf("%s 上传成功.\n", filepath.Join(file, subFile.Name()))
 		}
+		if err := r.cli.checkoutToParentDir(); err != nil {
+			return err
 	}
 	return nil
 }


### PR DESCRIPTION
使用上层栈传入的driveID和fileID保持文件夹结构
修复上传文件夹时子文件夹完成后路径栈未出栈