### PR TITLE
修复嵌套文件夹上传路径错误

### DIFF
--- a/internal/command_upload.go
+++ b/internal/command_upload.go
@@ -75,8 +75,8 @@ func (r *CommandUpload) upload(file string, driveID string, fileID string) error
 			log.Fatal(err)
 		}
 		response, err := r.cli.ali.File.CreateFolder(context.Background(), &aliyundrive.CreateFolderReq{
-			DriveID:      r.cli.driveID,
-			ParentFileID: r.cli.currentFileID,
+			DriveID:      driveID,
+			ParentFileID: fileID,
 			Name:         fileInfo.Name(),
 		})
 		if err != nil {
@@ -91,6 +91,9 @@ func (r *CommandUpload) upload(file string, driveID string, fileID string) error
 				return err
 			}
 			fmt.Printf("%s 上传成功.\n", filepath.Join(file, subFile.Name()))
+		}
+		if err := r.cli.checkoutToParentDir(); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
修复嵌套文件夹上传完子文件夹没有退回上层文件夹导致的嵌套结构错误